### PR TITLE
[fix] Cosmetic fixes and details

### DIFF
--- a/app/assets/stylesheets/tile.scss
+++ b/app/assets/stylesheets/tile.scss
@@ -72,6 +72,6 @@
 }
 
 .pinned {
-    background: url(pin.svg) #fff8dc right 4px top 4px /16px no-repeat !important;
+    background: url(pin.svg) #fff right 4px top 4px /16px no-repeat !important;
     border: 1px solid #e0dcfb !important;
 }

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -31,17 +31,17 @@
           - if post.decorate.can_pin?
             - if post.pinned?
               %li
-              = link_to 'Unpin', toggle_pin_post_path(post), method: :put, remote: true
+                = link_to 'Unpin', toggle_pin_post_path(post), method: :put, remote: true
             - else
               %li
-              = link_to 'Pin', toggle_pin_post_path(post), method: :put, remote: true
+                = link_to 'Pin', toggle_pin_post_path(post), method: :put, remote: true
           - if post.decorate.can_modified?
             %li
-            = link_to 'Delete', post_path(post),
+              = link_to 'Delete', post_path(post),
             method: :delete, remote: true,
             data: { confirm_target: '#post_delete_confirmation_modal' }
             %li
-            = link_to 'Edit',
+              = link_to 'Edit',
             edit_post_path(post, request_from: request_from), remote: true
           - else
             - unless post.decorate.mine?


### PR DESCRIPTION
- 🐛 [FIX] The dropdown menu is missing the stylesheet that was there
before it was caused by a wrong haml indentation at = link_to files in
app/views/posts/_post.html.haml
- ⏪ [CHANGE] Revert the yellow background color to white for the pinned
post at .pinned style class in app/assets/stylesheets/tile.scss