### PR TITLE
[fix] Allow people who aren't logged in to read the forum replies (fixes #15)

### DIFF
--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -61,7 +61,6 @@
             Write a response…
         .response_box_form
           = render 'replies/reply_form', replicable: @post
-        = render 'replies/list_replies', replies: @post.replies, report_parent: @post
       - else
         .forum-card.response_box_no_user
           .center-text
@@ -70,6 +69,7 @@
             or
             = link_to 'sign up', new_registration_path(resource_name)
             to reply
+      = render 'replies/list_replies', replies: @post.replies, report_parent: @post
 
 
 .mb-50

--- a/app/views/replies/_reply.html.haml
+++ b/app/views/replies/_reply.html.haml
@@ -13,4 +13,5 @@
       locals: { report_parent: report_parent }
 
     .reply-container{:id=>'reply-container-'+reply.id.to_s}
-      = render 'replies/reply_form', replicable: reply, children: children
+      - if user_signed_in?
+        = render 'replies/reply_form', replicable: reply, children: children

--- a/app/views/replies/_reply_content.html.haml
+++ b/app/views/replies/_reply_content.html.haml
@@ -8,7 +8,10 @@
   .reply.pull-left
     %span.middle-dot
       &#183;
-      = link_to "Reply", '#', class: 'reply-link', :data => { id: reply.id }
+      - if user_signed_in?
+        = link_to "Reply", '#', class: 'reply-link', :data => { id: reply.id }
+      - else
+        = link_to 'Reply', new_session_path(resource_name)
   .forum-time.pull-right
     .platform_timestamp{"data-time-stamp"=>reply.created_at}=platform_timestamp(reply.created_at)
     .dropdown.pull-right


### PR DESCRIPTION
Fixes #15 
I didn't know how was the best way to prompt the user to login when they click "reply", so I just decided to redirect the user to the login page, when they login or sign up, they get redirected again to the post they were before.