### PR TITLE
Fix #43 Adding COALESCE operator to the filter query.

### DIFF
--- a/app/services/filter/post_filter.rb
+++ b/app/services/filter/post_filter.rb
@@ -42,9 +42,9 @@ module Filter
       end
 
       if @params[:category].to_s == TRENDING
-        order_clause = "posts.pinned desc, replies_count desc, MAX(replies.updated_at) desc, posts.created_at desc"
+        order_clause = "posts.pinned desc, replies_count desc, coalesce(MAX(replies.updated_at), posts.created_at) desc"
       else
-        order_clause = "posts.pinned desc, MAX(replies.updated_at) desc, posts.created_at desc"
+        order_clause = "posts.pinned desc, coalesce(MAX(replies.updated_at), posts.created_at) desc"
       end
 
       puts where_clause


### PR DESCRIPTION
Coalesce will return the timestamp of the last answer or the timestamp
of the post, (in the case it has no answers), and then the order_clause
will sort the posts list by that obtained timestamp.