### PR TITLE
Fix featured image tiles

### DIFF
--- a/app/views/programs/_featured.html.haml
+++ b/app/views/programs/_featured.html.haml
@@ -1,6 +1,6 @@
 - col ||= 'col-md-12 col-sm-6'
 %div.tilter.tilter--3{class: col}
-  .program-tile-container.tilter__figure{style: "background-image: url(#{program.cover.url(:medium)});"}
+  .program-tile-container.tilter__figure{style: "background-image: url(#{program.cover.url(:medium)}); background-size: cover;"}
     .overlay-tint
       = link_to program do
         .program-tile-detail


### PR DESCRIPTION
This is a minor fix for featured image tiles. Fixes the following problem where the background repeats:
https://i.gyazo.com/947d85cea1571020c3552ddb592757ba.png

Btw let me know if I'm doing this right in the .haml file because I've never used it before and I also I did not setup the whole project locally, so it's pretty much a guess from my side.